### PR TITLE
Work with setuptools_scm 8.0 (fix #50)

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -78,7 +78,7 @@ def test_write(new_project_write):
     version_starts = ('version = ', '__version__ = ')
     assert any(line.startswith(version_starts) for line in lines)
     version_line = next(line for line in lines if line.startswith(version_starts))
-    assert version_line.endswith(" = '1.2.3'")
+    assert " = '1.2.3'" in version_line
 
 
 @pytest.mark.skipif(sys.version_info[0] == 2, reason='Depends on fix in 6.4.0 which is Python 3-only')


### PR DESCRIPTION
Make test_write even less brittle (see also #8, #9, #25) so that it works with _version.py files generated by at least setuptools_scm 8.0, 7.1, 7.0, and 6.4.

This is required because setuptools_scm 8.0 added a type-checking comment at the end of the version line.

This is a follow-up to https://github.com/ofek/hatch-vcs/pull/26.