### PR TITLE
Don’t use deprecated shutil.rmtree(onerror=…) in Python 3.12+

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def temp_dir():
         directory = os.path.realpath(directory)
         yield directory
     finally:
-        if version_info >= (3, 12):
+        if version_info[:2] >= (3, 12):
             onexc = dict(onexc=handle_remove_readonly)
         else:
             onexc = dict(onerror=lambda func, path, exc: handle_remove_readonly(func, path, exc[1]))


### PR DESCRIPTION
The [replacement is `shutil.rmtree(onexc=…)`](https://docs.python.org/3.12/library/shutil.html#shutil.rmtree), which receives the exception instead of the sys.exc_info() tuple as the third argument.

Unfortunately, explicitly testing the Python version number seems to be required. See also https://github.com/pypa/pip/pull/12137.

Fixes a `DeprecationWarning` like

```
================================================== warnings summary ==================================================
tests/test_build.py: 5 warnings
tests/test_build_config.py: 6 warnings
tests/test_metadata_config.py: 4 warnings
tests/test_version_config.py: 7 warnings
  /home/ben/src/forks/hatch-vcs/tests/conftest.py:32: DeprecationWarning: onerror argument is deprecated, use onexc instead
    shutil.rmtree(directory, ignore_errors=False, onerror=handle_remove_readonly)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

when running the tests on Python 3.12.