### PR TITLE
Don’t use deprecated shutil.rmtree(onerror=…) in Python 3.12+ (alternative approach)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import tempfile
 from contextlib import contextmanager
 from sys import version_info
 
-if version_info >= (3, 12):
+if version_info[:2] >= (3, 12):
     from shutil import rmtree
 else:
     from shutil import rmtree as _rmtree

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,22 @@ import shutil
 import stat
 import tempfile
 from contextlib import contextmanager
+from sys import version_info
+
+if version_info >= (3, 12):
+    from shutil import rmtree
+else:
+    from shutil import rmtree as _rmtree
+
+    # Wrap rmtree to backport the onexc keyword argument from Python 3.12
+    def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
+        if "onexc" in kwds:
+            kwds = dict(kwds)
+            onexc = kwds.pop("onexc")
+
+            def onerror(func, path, exc):
+                return onexc(func, path, exc[1])
+        return _rmtree(path, ignore_errors, onerror, *args, **kwds)
 
 import pytest
 
@@ -15,7 +31,7 @@ from .utils import create_file, git, write_file
 
 def handle_remove_readonly(func, path, exc):  # no cov
     # PermissionError: [WinError 5] Access is denied: '...\\.git\\...'
-    if func in (os.rmdir, os.remove, os.unlink) and exc[1].errno == errno.EACCES:
+    if func in (os.rmdir, os.remove, os.unlink) and exc.errno == errno.EACCES:
         os.chmod(path, stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO)  # noqa: S103
         func(path)
     else:
@@ -29,7 +45,7 @@ def temp_dir():
         directory = os.path.realpath(directory)
         yield directory
     finally:
-        shutil.rmtree(directory, ignore_errors=False, onerror=handle_remove_readonly)
+        rmtree(directory, ignore_errors=False, onexc=handle_remove_readonly)
 
 
 @contextmanager


### PR DESCRIPTION
The replacement is `shutil.rmtree(onexc=…)`, which receives the exception instead of the `sys.exc_info()` tuple as the third argument.

Unfortunately, explicitly testing the Python version number seems to be required. See also https://github.com/pypa/pip/pull/12137.

This accomplishes the same goal as https://github.com/ofek/hatch-vcs/pull/52, but approaches it very differently.