### PR TITLE
Fix some linter/typechecker findings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,9 @@ else:
 
             def onerror(func, path, exc):
                 return onexc(func, path, exc[1])
+
         return _rmtree(path, ignore_errors, onerror, *args, **kwds)
+
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ else:
     # Backport the onexc keyword argument from Python 3.12
     @wraps(_rmtree)
     def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
-        if "onexc" in kwds:
+        if 'onexc' in kwds:
             kwds = dict(kwds)
-            onexc = kwds.pop("onexc")
+            onexc = kwds.pop('onexc')
 
             def onerror(func, path, exc):
                 return onexc(func, path, exc[1])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 import errno
 import os
-import shutil
 import stat
 import tempfile
 from contextlib import contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ else:
 
     # Backport the onexc keyword argument from Python 3.12
     @wraps(_rmtree)
-    def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
+    def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):  # noqa: FBT002
         if 'onexc' in kwds:
             kwds = dict(kwds)
             onexc = kwds.pop('onexc')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import tempfile
 from contextlib import contextmanager
+from functools import wraps
 from sys import version_info
 
 if version_info[:2] >= (3, 12):
@@ -14,7 +15,8 @@ if version_info[:2] >= (3, 12):
 else:
     from shutil import rmtree as _rmtree
 
-    # Wrap rmtree to backport the onexc keyword argument from Python 3.12
+    # Backport the onexc keyword argument from Python 3.12
+    @wraps(_rmtree)
     def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
         if "onexc" in kwds:
             kwds = dict(kwds)


### PR DESCRIPTION
This fixes a few of the things that `mypy`, `ruff`, and `black` were complaining about, as suggested in https://github.com/ofek/hatch-vcs/pull/51#issuecomment-1731758891.

-----

The following complaints from `ruff` remain:

```
hatch_vcs/vcs_utils.py:10:36: S603 `subprocess` call: check for execution of untrusted input
tests/utils.py:38:32: S603 `subprocess` call: check for execution of untrusted input
```

https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/

```
hatch_vcs/vcs_utils.py:10:36: S607 Starting a process with a partial executable path
```

https://docs.astral.sh/ruff/rules/start-process-with-partial-path/