### PR TITLE
RF: Change build hook properties to cached properties

### DIFF
--- a/hatch_vcs/build_hook.py
+++ b/hatch_vcs/build_hook.py
@@ -1,43 +1,30 @@
 # SPDX-FileCopyrightText: 2022-present Ofek Lev <oss@ofek.dev>
 #
 # SPDX-License-Identifier: MIT
-from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from functools import cached_property
 
-sentinel = object()
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class VCSBuildHook(BuildHookInterface):
     PLUGIN_NAME = 'vcs'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.__config_version_file = None
-        self.__config_template = sentinel
-
-    @property
+    @cached_property
     def config_version_file(self):
-        if self.__config_version_file is None:
-            version_file = self.config.get('version-file', '')
-            if not isinstance(version_file, str):
-                raise TypeError(f'Option `version-file` for build hook `{self.PLUGIN_NAME}` must be a string')
-            elif not version_file:
-                raise ValueError(f'Option `version-file` for build hook `{self.PLUGIN_NAME}` is required')
+        version_file = self.config.get('version-file')
+        if not version_file:
+            raise ValueError(f'Option `version-file` for build hook `{self.PLUGIN_NAME}` is required')
+        elif not isinstance(version_file, str):
+            raise TypeError(f'Option `version-file` for build hook `{self.PLUGIN_NAME}` must be a string')
 
-            self.__config_version_file = version_file
+        return version_file
 
-        return self.__config_version_file
-
-    @property
+    @cached_property
     def config_template(self):
-        if self.__config_template is sentinel:
-            template = self.config.get('template')
-            if template is not None and not isinstance(template, str):
-                raise TypeError(f'Option `template` for build hook `{self.PLUGIN_NAME}` must be a string')
-
-            self.__config_template = template
-
-        return self.__config_template
+        template = self.config.get('template')
+        if template is not None and not isinstance(template, str):
+            raise TypeError(f'Option `template` for build hook `{self.PLUGIN_NAME}` must be a string')
+        return template
 
     def initialize(self, version, build_data):
         from setuptools_scm import dump_version


### PR DESCRIPTION
Follow-up to #55 and #56. This removes the custom implementation of cached properties for `functools.cached_property`, which was added in Python 3.8.