### PR TITLE
STY: Fix style issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,10 +83,8 @@ ignore = [
   "FBT003",
   # Ignore checks for possible passwords
   "S105", "S106", "S107",
-]
-unfixable = [
-  # Don't touch unused imports
-  "F401",
+  # Boolean default values
+  "FBT002",
 ]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ ignore = [
   "FBT003",
   # Ignore checks for possible passwords
   "S105", "S106", "S107",
+  # Ignore noisy checks for insecure subprocess calls
+  "S603", "S607",
   # Boolean default values
   "FBT002",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import stat
 import tempfile
 from contextlib import contextmanager
+from functools import wraps
 from sys import version_info
 
 if version_info[:2] >= (3, 12):
@@ -13,7 +14,8 @@ if version_info[:2] >= (3, 12):
 else:
     from shutil import rmtree as _rmtree
 
-    # Wrap rmtree to backport the onexc keyword argument from Python 3.12
+    # Backport the onexc keyword argument from Python 3.12
+    @wraps(_rmtree)
     def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
         if 'onexc' in kwds:
             kwds = dict(kwds)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 import errno
 import os
-import shutil
 import stat
 import tempfile
 from contextlib import contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,13 +16,15 @@ else:
 
     # Wrap rmtree to backport the onexc keyword argument from Python 3.12
     def rmtree(path, ignore_errors=False, onerror=None, *args, **kwds):
-        if "onexc" in kwds:
+        if 'onexc' in kwds:
             kwds = dict(kwds)
-            onexc = kwds.pop("onexc")
+            onexc = kwds.pop('onexc')
 
             def onerror(func, path, exc):
                 return onexc(func, path, exc[1])
+
         return _rmtree(path, ignore_errors, onerror, *args, **kwds)
+
 
 import pytest
 


### PR DESCRIPTION
Unclear why F401 needed to be "unfixable", so I removed it. The specific violation of FBT002 is unavoidable for compatibility, but it also doesn't seem like a useful check, so I ignored it generally instead of with a `#noqa`.

Closes #54.