### PR TITLE
Create directory for version file if necessary

### DIFF
--- a/hatch_vcs/build_hook.py
+++ b/hatch_vcs/build_hook.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 from functools import cached_property
+import os
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
@@ -32,6 +33,7 @@ class VCSBuildHook(BuildHookInterface):
         kwargs = {}
         if self.config_template:
             kwargs['template'] = self.config_template
+        os.makedirs(os.path.dirname(self.config_version_file), exist_ok=True)
         dump_version(self.root, self.metadata.version, self.config_version_file, **kwargs)
 
         build_data['artifacts'].append(f'/{self.config_version_file}')


### PR DESCRIPTION
Would you be open to automatically creating the directory if it doesn't exist?

My use case is that `uv build` copies the source tree to a new hermetic location and in my workspace root (which is a meta package, not one that is actually published) I need the _version.py to be placed in `dist`, which doesn't exist yet when this is run. Writing a custom hook just for this seemed wasteful :)