### PR TITLE
feat(dependency): increase minimum version of setuptools-scm dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
   "hatchling>=1.1.0",
-  "setuptools-scm>=6.4.0",
+  "setuptools-scm>=8.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Increase the minimum version for setuptools-scm.

This helps consumers of hatch-vcs to test their package with the minimum suported versions of dependencies.
Earlier versions of setuptools-scm did depend on setuptools without a version specifier. Using a tool that allows you to install the earliest supported version of every packages ends up installing setuptools 0.x which would fail of course.
Starting with setuptools-scm 8.2.0, the minimum version is 60 something.