### PR TITLE
gitignore version file used in write project fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def create_project(directory, metadata, *, setup_vcs=True, nested=False):
     os.mkdir(root_dir)
 
     gitignore_file = os.path.join(root_dir, '.gitignore')
-    write_file(gitignore_file, '/my_app/version.py')
+    write_file(gitignore_file, '/my_app/_version.py')
 
     if nested:
         project_dir = os.path.join(root_dir, 'project')


### PR DESCRIPTION
I believe the intention is to gitignore the version file referenced in the `new_project_write` fixture to test whether gitignoring the file will still add it as an artifact, as tested in `test_build.py::test_write`