### PR TITLE
feat(version-source): mirror setuptools_scm override env vars for version

### DIFF
--- a/hatch_vcs/__about__.py
+++ b/hatch_vcs/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present Ofek Lev <oss@ofek.dev>
 #
 # SPDX-License-Identifier: MIT
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/hatch_vcs/version_source.py
+++ b/hatch_vcs/version_source.py
@@ -69,9 +69,9 @@ class VCSVersionSource(VersionSourceInterface):
         return config
 
     def get_version_data(self):
-        if os.getenv("HATCH_VERSION_OVERRIDE", default=None) is not None:
-            return {'version': os.getenv("HATCH_VERSION_OVERRIDE")}
-        
+        if os.getenv('HATCH_VERSION_OVERRIDE', default=None) is not None:
+            return {'version': os.getenv('HATCH_VERSION_OVERRIDE')}
+
         from setuptools_scm import get_version
 
         version = get_version(**self.construct_setuptools_scm_config())

--- a/hatch_vcs/version_source.py
+++ b/hatch_vcs/version_source.py
@@ -69,9 +69,9 @@ class VCSVersionSource(VersionSourceInterface):
         return config
 
     def get_version_data(self):
-        # Check for setuptools_scm override environment variables
-        # 1. SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${DIST_NAME}
-        # 2. SETUPTOOLS_SCM_PRETEND_VERSION
+        # Check for hatch-vcs override environment variables
+        # 1. HATCH_VCS_PRETEND_VERSION_FOR_${DIST_NAME}
+        # 2. HATCH_VCS_PRETEND_VERSION
         # 3. HATCH_VERSION_OVERRIDE (legacy)
         # Try to extract the dist name from config, else fallback to test fixture, else basename
         dist_name = self.config.get('dist_name')
@@ -82,10 +82,10 @@ class VCSVersionSource(VersionSourceInterface):
             else:
                 dist_name = self.root.name if hasattr(self.root, 'name') else os.path.basename(self.root)
         norm_dist_name = dist_name.replace('-', '_').replace('.', '_').replace('/', '_').upper()
-        env_var_specific = f'SETUPTOOLS_SCM_PRETEND_VERSION_FOR_{norm_dist_name}'
+        env_var_specific = f'HATCH_VCS_PRETEND_VERSION_FOR_{norm_dist_name}'
         version_override = os.getenv(env_var_specific)
         if version_override is None:
-            version_override = os.getenv('SETUPTOOLS_SCM_PRETEND_VERSION')
+            version_override = os.getenv('HATCH_VCS_PRETEND_VERSION')
         if version_override is None:
             version_override = os.getenv('HATCH_VERSION_OVERRIDE')
         if version_override is not None:

--- a/hatch_vcs/version_source.py
+++ b/hatch_vcs/version_source.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present Ofek Lev <oss@ofek.dev>
 #
 # SPDX-License-Identifier: MIT
+import os
+
 from hatchling.version.source.plugin.interface import VersionSourceInterface
 
 
@@ -67,6 +69,9 @@ class VCSVersionSource(VersionSourceInterface):
         return config
 
     def get_version_data(self):
+        if os.getenv("HATCH_VERSION_OVERRIDE", default=None) is not None:
+            return {'version': os.getenv("HATCH_VERSION_OVERRIDE")}
+        
         from setuptools_scm import get_version
 
         version = get_version(**self.construct_setuptools_scm_config())

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -103,17 +103,17 @@ def test_get_version_data_env_override(monkeypatch, new_project_basic):
     config = {}
     version_source = VCSVersionSource(new_project_basic, config)
     monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
-    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION', raising=False)
-    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    monkeypatch.delenv('HATCH_VCS_PRETEND_VERSION', raising=False)
+    monkeypatch.delenv('HATCH_VCS_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
     assert version_source.get_version_data() == {'version': 'override-version'}
 
 
 def test_get_version_data_setuptools_scm_pretend_version(monkeypatch, new_project_basic):
     config = {}
     version_source = VCSVersionSource(new_project_basic, config)
-    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.setenv('HATCH_VCS_PRETEND_VERSION', 'pretend-version')
     monkeypatch.delenv('HATCH_VERSION_OVERRIDE', raising=False)
-    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    monkeypatch.delenv('HATCH_VCS_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
     assert version_source.get_version_data() == {'version': 'pretend-version'}
 
 
@@ -121,8 +121,8 @@ def test_get_version_data_setuptools_scm_pretend_version_for_dist(monkeypatch, n
     config = {'dist_name': 'new_project_basic'}
     version_source = VCSVersionSource(new_project_basic, config)
     # The normalized dist name for the test fixture is 'new_project_basic', uppercase and underscores
-    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
-    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.setenv('HATCH_VCS_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
+    monkeypatch.setenv('HATCH_VCS_PRETEND_VERSION', 'pretend-version')
     monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
     assert version_source.get_version_data() == {'version': 'specific-pretend-version'}
 
@@ -130,14 +130,14 @@ def test_get_version_data_setuptools_scm_pretend_version_for_dist(monkeypatch, n
 def test_get_version_data_env_precedence(monkeypatch, new_project_basic):
     config = {'dist_name': 'new_project_basic'}
     version_source = VCSVersionSource(new_project_basic, config)
-    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
-    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.setenv('HATCH_VCS_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
+    monkeypatch.setenv('HATCH_VCS_PRETEND_VERSION', 'pretend-version')
     monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
     # Should prefer the specific dist override
     assert version_source.get_version_data() == {'version': 'specific-pretend-version'}
-    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    monkeypatch.delenv('HATCH_VCS_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
     # Should prefer the generic override
     assert version_source.get_version_data() == {'version': 'pretend-version'}
-    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION', raising=False)
+    monkeypatch.delenv('HATCH_VCS_PRETEND_VERSION', raising=False)
     # Should prefer the legacy override
     assert version_source.get_version_data() == {'version': 'override-version'}

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -103,4 +103,41 @@ def test_get_version_data_env_override(monkeypatch, new_project_basic):
     config = {}
     version_source = VCSVersionSource(new_project_basic, config)
     monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
+    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION', raising=False)
+    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    assert version_source.get_version_data() == {'version': 'override-version'}
+
+
+def test_get_version_data_setuptools_scm_pretend_version(monkeypatch, new_project_basic):
+    config = {}
+    version_source = VCSVersionSource(new_project_basic, config)
+    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.delenv('HATCH_VERSION_OVERRIDE', raising=False)
+    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    assert version_source.get_version_data() == {'version': 'pretend-version'}
+
+
+def test_get_version_data_setuptools_scm_pretend_version_for_dist(monkeypatch, new_project_basic):
+    config = {'dist_name': 'new_project_basic'}
+    version_source = VCSVersionSource(new_project_basic, config)
+    # The normalized dist name for the test fixture is 'new_project_basic', uppercase and underscores
+    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
+    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
+    assert version_source.get_version_data() == {'version': 'specific-pretend-version'}
+
+
+def test_get_version_data_env_precedence(monkeypatch, new_project_basic):
+    config = {'dist_name': 'new_project_basic'}
+    version_source = VCSVersionSource(new_project_basic, config)
+    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', 'specific-pretend-version')
+    monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'pretend-version')
+    monkeypatch.setenv('HATCH_VERSION_OVERRIDE', 'override-version')
+    # Should prefer the specific dist override
+    assert version_source.get_version_data() == {'version': 'specific-pretend-version'}
+    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION_FOR_NEW_PROJECT_BASIC', raising=False)
+    # Should prefer the generic override
+    assert version_source.get_version_data() == {'version': 'pretend-version'}
+    monkeypatch.delenv('SETUPTOOLS_SCM_PRETEND_VERSION', raising=False)
+    # Should prefer the legacy override
     assert version_source.get_version_data() == {'version': 'override-version'}


### PR DESCRIPTION
## Description
We use hatch-vcs in all of our projects. There is a specific version format that they push to us on our build pipeline to align with their SCM reporting. The HATCH_VERSION_OVERRIDE variable will allow me to set that prior to our build so that their requirement is being used.

If this variable is not set then then default behavior takes over.